### PR TITLE
Add spatial grid acceleration for ray-dioptre intersection tests

### DIFF
--- a/breakout.js
+++ b/breakout.js
@@ -28,6 +28,7 @@ let lights = [];
 let backgrounds = [];
 
 let songs = [];
+let spatialGrid;
 
 function preload() {
   const ballImages = ['ballon.png', 'basket.png', 'smiley.png', 'tennis.png'];
@@ -49,6 +50,8 @@ function setup() {
   engine = Engine.create();
   world = engine.world;
   engine.world.gravity.y = 0;
+
+  spatialGrid = new SpatialGrid(CONFIG.CANVAS_WIDTH, CONFIG.CANVAS_HEIGHT, CONFIG.GRID_CELL_SIZE);
 
   lights.push(new Light(width / 2, height / 2, color(255, 255, 255, 64), dioptres));
 
@@ -182,6 +185,14 @@ function draw() {
   drawPaddle();
   drawLights();
 
+  if (CONFIG.SHOW_FPS) {
+    blendMode(BLEND);
+    noStroke();
+    fill(255, 255, 0);
+    textSize(14);
+    text('FPS: ' + frameRate().toFixed(1), 10, 20);
+  }
+
   Engine.update(engine);
 }
 
@@ -189,6 +200,12 @@ function updateDioptres() {
   resetDioptres();
   for (let i = 0; i < boxes.length; i++) {
     boxes[i].pushDioptres();
+  }
+  paddle.pushDioptres();
+  spatialGrid.updateMaxDioptres(dioptreCount);
+  spatialGrid.build(dioptres, dioptreCount);
+  for (const light of lights) {
+    light.grid = spatialGrid;
   }
 }
 
@@ -215,6 +232,5 @@ function drawBalls() {
 }
 
 function drawPaddle() {
-  paddle.pushDioptres();
   paddle.show();
 }

--- a/gravity.js
+++ b/gravity.js
@@ -20,6 +20,7 @@ let lights = [];
 let dioptres = [];
 let canvasCentre;
 let time = 0;
+let spatialGrid;
 
 function preload() {
   const ballImages = ['ballon.png', 'basket.png', 'smiley.png', 'tennis.png'];
@@ -34,6 +35,8 @@ function setup() {
 
   engine = Engine.create();
   world = engine.world;
+
+  spatialGrid = new SpatialGrid(CONFIG.CANVAS_WIDTH, CONFIG.CANVAS_HEIGHT, CONFIG.GRID_CELL_SIZE);
 
   resetDioptres();
 
@@ -57,6 +60,14 @@ function draw() {
   drawBalls();
   drawLights();
 
+  if (CONFIG.SHOW_FPS) {
+    blendMode(BLEND);
+    noStroke();
+    fill(255, 255, 0);
+    textSize(14);
+    text('FPS: ' + frameRate().toFixed(1), 10, 20);
+  }
+
   Engine.update(engine);
 }
 
@@ -64,6 +75,11 @@ function updateDioptres() {
   resetDioptres();
   for (let i = balls.length - 1; i >= 0; i--) {
     balls[i].pushDioptres();
+  }
+  spatialGrid.updateMaxDioptres(dioptreCount);
+  spatialGrid.build(dioptres, dioptreCount);
+  for (const light of lights) {
+    light.grid = spatialGrid;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <script src="lightphysics/ray.js"></script>
     <script src="lightphysics/dioptre.js"></script>
     <script src="lightphysics/light.js"></script>
+    <script src="lightphysics/spatial-grid.js"></script>
     <script src="lightphysics/matter.min.js"></script>
     <script src="lightphysics/utils.js"></script>
     <script src="lightphysics/physics-object.js"></script>

--- a/index_debug.html
+++ b/index_debug.html
@@ -15,6 +15,7 @@
     <script src="lightphysics/ray.js"></script>
     <script src="lightphysics/dioptre.js"></script>
     <script src="lightphysics/light.js"></script>
+    <script src="lightphysics/spatial-grid.js"></script>
     <script src="lightphysics/matter.js"></script>
     <script src="lightphysics/utils.js"></script>
     <script src="lightphysics/physics-object.js"></script>

--- a/lightphysics/ball.js
+++ b/lightphysics/ball.js
@@ -33,7 +33,7 @@ class Ball extends PhysicsObject {
             const angle2 = ((i + 1) % CONFIG.BALL_SEGMENTS) * angleStep;
             const pt1 = rotatePt(cx + this.r * Math.cos(angle1), cy + this.r * Math.sin(angle1), cx, cy, cosA, sinA);
             const pt2 = rotatePt(cx + this.r * Math.cos(angle2), cy + this.r * Math.sin(angle2), cx, cy, cosA, sinA);
-            dioptres.push(new Dioptre(pt1.x, pt1.y, pt2.x, pt2.y));
+            pushDioptre(pt1.x, pt1.y, pt2.x, pt2.y);
         }
     }
 

--- a/lightphysics/box.js
+++ b/lightphysics/box.js
@@ -52,9 +52,9 @@ class Box extends PhysicsObject {
         const c = rotatePt(maxx, maxy, cx, cy, cosA, sinA);
         const d = rotatePt(minx, maxy, cx, cy, cosA, sinA);
 
-        dioptres.push(new Dioptre(a.x, a.y, b.x, b.y));
-        dioptres.push(new Dioptre(b.x, b.y, c.x, c.y));
-        dioptres.push(new Dioptre(c.x, c.y, d.x, d.y));
-        dioptres.push(new Dioptre(d.x, d.y, a.x, a.y));
+        pushDioptre(a.x, a.y, b.x, b.y);
+        pushDioptre(b.x, b.y, c.x, c.y);
+        pushDioptre(c.x, c.y, d.x, d.y);
+        pushDioptre(d.x, d.y, a.x, a.y);
     }
 }

--- a/lightphysics/config.js
+++ b/lightphysics/config.js
@@ -18,4 +18,6 @@ const CONFIG = Object.freeze({
     VELOCITY_BOOST: 1.2,
     BREAKOUT_BALL_VELOCITY: 3,
     BREAKOUT_BALL_RADIUS: 8,
+    GRID_CELL_SIZE: 80,
+    SHOW_FPS: true,
 });

--- a/lightphysics/dioptre.js
+++ b/lightphysics/dioptre.js
@@ -8,13 +8,22 @@
 
 class Dioptre {
   constructor(x1, y1, x2, y2) {
-    this.a = createVector(x1, y1);
-    this.b = createVector(x2, y2);
+    this.ax = x1;
+    this.ay = y1;
+    this.bx = x2;
+    this.by = y2;
+  }
+
+  set(x1, y1, x2, y2) {
+    this.ax = x1;
+    this.ay = y1;
+    this.bx = x2;
+    this.by = y2;
   }
 
   show() {
     strokeWeight(1);
     stroke(100);
-    line(this.a.x, this.a.y, this.b.x, this.b.y);
+    line(this.ax, this.ay, this.bx, this.by);
   }
 }

--- a/lightphysics/light.js
+++ b/lightphysics/light.js
@@ -12,8 +12,16 @@ class Light {
     this.color = color;
     this.rays = [];
     this.dioptres = dioptres;
-    this.lightImg = createGraphics(width, height);
     this.showRays = false;
+    this.grid = null;
+    this.initRays();
+  }
+
+  initRays() {
+    this.rays = [];
+    for (let a = 0; a < 360; a += CONFIG.RAY_ANGLE_STEP) {
+      this.rays.push(new Ray(this.pos, radians(a), this.color));
+    }
   }
 
   update(x, y) {
@@ -27,36 +35,20 @@ class Light {
     }
   }
 
-  generateBasicRays() {
-    this.rays = [];
-    for (let a = 0; a < 360; a += CONFIG.RAY_ANGLE_STEP) {
-      this.rays.push(new Ray(this.pos, radians(a), this.color));
-    }
-  }
-
   show() {
-    this.generateLightImg();
-    image(this.lightImg, 0, 0);
+    this.lookRayCollision();
+
+    fill(this.color);
+    noStroke();
+    beginShape();
+    for (const ray of this.rays) {
+      vertex(ray.end.x, ray.end.y);
+    }
+    endShape(CLOSE);
 
     if (this.showRays) {
       this.renderBestRays();
     }
-  }
-
-  generateLightImg() {
-    this.generateBasicRays();
-    this.lookRayCollision();
-
-    this.lightImg.clear();
-    this.lightImg.push();
-    this.lightImg.fill(this.color);
-    this.lightImg.noStroke();
-    this.lightImg.beginShape();
-    for (const ray of this.rays) {
-      this.lightImg.vertex(ray.end.x, ray.end.y);
-    }
-    this.lightImg.endShape(CLOSE);
-    this.lightImg.pop();
   }
 
   compareNumbers(a, b) {
@@ -64,8 +56,14 @@ class Light {
   }
 
   lookRayCollision() {
-    for (const ray of this.rays) {
-      ray.calculateIntersection(dioptres);
+    if (this.grid) {
+      for (const ray of this.rays) {
+        ray.calculateIntersectionWithGrid(dioptres, this.grid);
+      }
+    } else {
+      for (const ray of this.rays) {
+        ray.calculateIntersection(dioptres, dioptreCount);
+      }
     }
   }
 
@@ -79,56 +77,6 @@ class Light {
     stroke(color(255, 0, 0, 255));
     for (const ray of this.rays) {
       ray.show();
-    }
-  }
-
-  cleanBadRays() {
-    const epsilon = 20;
-
-    for (let i = 1; i < this.rays.length - 1; i++) {
-      const prev = this.rays[i - 1];
-      const current = this.rays[i];
-      const next = this.rays[i + 1];
-
-      const distPrev = Math.sqrt(Math.pow(current.end.x - prev.end.x, 2) + Math.pow(current.end.y - prev.end.y, 2));
-      const distNext = Math.sqrt(Math.pow(current.end.x - next.end.x, 2) + Math.pow(current.end.y - next.end.y, 2));
-
-      if (distPrev < epsilon || distNext < epsilon) {
-        this.rays.splice(i, 1);
-        i--;
-      }
-    }
-    this.rays.splice(0, 1);
-    this.rays.splice(this.rays.length - 1, 1);
-  }
-
-  renderLightPolygon() {
-    fill(this.color);
-    noStroke();
-
-    beginShape();
-    for (let i = 0; i < this.closests.length; i++) {
-      vertex(this.closests[i].x, this.closests[i].y);
-    }
-    endShape(CLOSE);
-  }
-
-  renderLightPolygonLimits() {
-    noFill();
-    stroke(255, 255, 255, 128);
-
-    let px = this.closests[0].x;
-    let py = this.closests[0].y;
-    for (let i = 0; i < this.closests.length; i++) {
-      if (!((px === 0) || (py === 0) || (px === width) || (py === height))) {
-        if (!((this.closests[i].x === 0) || (this.closests[i].y === 0) || (this.closests[i].x === width) || (this.closests[i].y === height))) {
-          if (this.dioptreNbrs[i - 1] === this.dioptreNbrs[i]) {
-            line(px, py, this.closests[i].x, this.closests[i].y);
-          }
-        }
-      }
-      px = this.closests[i].x;
-      py = this.closests[i].y;
     }
   }
 }

--- a/lightphysics/paddle.js
+++ b/lightphysics/paddle.js
@@ -16,12 +16,12 @@ class Paddle extends PhysicsObject {
 
     pushDioptres() {
         const pos = this.body.position;
-        dioptres.push(new Dioptre(pos.x - this.w / 2, pos.y + this.h / 2, pos.x + this.w / 2, pos.y + this.h / 2));
-        dioptres.push(new Dioptre(pos.x + this.w / 2, pos.y + this.h / 2, pos.x + this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3));
-        dioptres.push(new Dioptre(pos.x + this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3, pos.x + this.w / 4, pos.y + this.h / 2 - this.h));
-        dioptres.push(new Dioptre(pos.x + this.w / 4, pos.y + this.h / 2 - this.h, pos.x - this.w / 4, pos.y + this.h / 2 - this.h));
-        dioptres.push(new Dioptre(pos.x - this.w / 4, pos.y + this.h / 2 - this.h, pos.x - this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3));
-        dioptres.push(new Dioptre(pos.x - this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3, pos.x - this.w / 2, pos.y + this.h / 2));
+        pushDioptre(pos.x - this.w / 2, pos.y + this.h / 2, pos.x + this.w / 2, pos.y + this.h / 2);
+        pushDioptre(pos.x + this.w / 2, pos.y + this.h / 2, pos.x + this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3);
+        pushDioptre(pos.x + this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3, pos.x + this.w / 4, pos.y + this.h / 2 - this.h);
+        pushDioptre(pos.x + this.w / 4, pos.y + this.h / 2 - this.h, pos.x - this.w / 4, pos.y + this.h / 2 - this.h);
+        pushDioptre(pos.x - this.w / 4, pos.y + this.h / 2 - this.h, pos.x - this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3);
+        pushDioptre(pos.x - this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3, pos.x - this.w / 2, pos.y + this.h / 2);
     }
 
     show() {

--- a/lightphysics/spatial-grid.js
+++ b/lightphysics/spatial-grid.js
@@ -1,0 +1,142 @@
+// 2D Raytracing Rendering for Matter.js
+// VERHILLE Arnaud
+// Copyleft GPL2
+//
+// Spatial grid for accelerating ray-dioptre intersection tests.
+// Divides the canvas into cells. Each dioptre is registered in
+// every cell it overlaps. A ray only tests dioptres in cells
+// along its path (DDA traversal).
+
+class SpatialGrid {
+  constructor(canvasWidth, canvasHeight, cellSize) {
+    this.cellSize = cellSize;
+    this.cols = Math.ceil(canvasWidth / cellSize);
+    this.rows = Math.ceil(canvasHeight / cellSize);
+    this.cells = new Array(this.cols * this.rows);
+    for (let i = 0; i < this.cells.length; i++) {
+      this.cells[i] = [];
+    }
+    this.canvasWidth = canvasWidth;
+    this.canvasHeight = canvasHeight;
+  }
+
+  clear() {
+    for (let i = 0; i < this.cells.length; i++) {
+      this.cells[i].length = 0;
+    }
+  }
+
+  build(dioptres, count) {
+    this.clear();
+    for (let i = 0; i < count; i++) {
+      this.insertDioptre(dioptres[i], i);
+    }
+  }
+
+  insertDioptre(dioptre, index) {
+    const cs = this.cellSize;
+    const minX = Math.max(0, Math.floor(Math.min(dioptre.ax, dioptre.bx) / cs));
+    const maxX = Math.min(this.cols - 1, Math.floor(Math.max(dioptre.ax, dioptre.bx) / cs));
+    const minY = Math.max(0, Math.floor(Math.min(dioptre.ay, dioptre.by) / cs));
+    const maxY = Math.min(this.rows - 1, Math.floor(Math.max(dioptre.ay, dioptre.by) / cs));
+
+    for (let y = minY; y <= maxY; y++) {
+      for (let x = minX; x <= maxX; x++) {
+        this.cells[y * this.cols + x].push(index);
+      }
+    }
+  }
+
+  getDioptresForRay(originX, originY, dirX, dirY) {
+    const cs = this.cellSize;
+    const cols = this.cols;
+    const rows = this.rows;
+
+    // Collect unique dioptre indices along the ray path using DDA
+    const seen = this._seen || (this._seen = new Uint8Array(1024));
+    const seenLen = this._seenLen || 0;
+
+    // Grow seen array if needed
+    if (seen.length < this._maxDioptres) {
+      this._seen = new Uint8Array(this._maxDioptres);
+    }
+
+    const result = this._resultBuf || (this._resultBuf = []);
+    result.length = 0;
+
+    // Clamp origin to canvas bounds for grid traversal
+    let x = Math.floor(originX / cs);
+    let y = Math.floor(originY / cs);
+
+    if (x < 0) x = 0;
+    if (x >= cols) x = cols - 1;
+    if (y < 0) y = 0;
+    if (y >= rows) y = rows - 1;
+
+    const stepX = dirX >= 0 ? 1 : -1;
+    const stepY = dirY >= 0 ? 1 : -1;
+
+    // Distance along ray for one full cell in X and Y
+    const tDeltaX = dirX !== 0 ? Math.abs(cs / dirX) : Infinity;
+    const tDeltaY = dirY !== 0 ? Math.abs(cs / dirY) : Infinity;
+
+    // Distance to first cell boundary
+    let tMaxX, tMaxY;
+    if (dirX >= 0) {
+      tMaxX = dirX !== 0 ? ((x + 1) * cs - originX) / dirX : Infinity;
+    } else {
+      tMaxX = dirX !== 0 ? (x * cs - originX) / dirX : Infinity;
+    }
+    if (dirY >= 0) {
+      tMaxY = dirY !== 0 ? ((y + 1) * cs - originY) / dirY : Infinity;
+    } else {
+      tMaxY = dirY !== 0 ? (y * cs - originY) / dirY : Infinity;
+    }
+
+    // Use a generation counter to avoid clearing the seen array each call
+    this._generation = (this._generation || 0) + 1;
+    const gen = this._generation;
+    if (gen > 250) {
+      // Reset to avoid overflow of Uint8Array values
+      this._generation = 1;
+      this._seen.fill(0);
+    }
+    const seenArr = this._seen;
+
+    // Traverse grid cells along ray
+    const maxSteps = cols + rows;
+    for (let step = 0; step < maxSteps; step++) {
+      if (x >= 0 && x < cols && y >= 0 && y < rows) {
+        const cell = this.cells[y * cols + x];
+        for (let i = 0; i < cell.length; i++) {
+          const idx = cell[i];
+          if (seenArr[idx] !== gen) {
+            seenArr[idx] = gen;
+            result.push(idx);
+          }
+        }
+      } else {
+        break;
+      }
+
+      // Step to next cell
+      if (tMaxX < tMaxY) {
+        x += stepX;
+        tMaxX += tDeltaX;
+      } else {
+        y += stepY;
+        tMaxY += tDeltaY;
+      }
+    }
+
+    return result;
+  }
+
+  updateMaxDioptres(count) {
+    this._maxDioptres = count;
+    if (!this._seen || this._seen.length < count) {
+      this._seen = new Uint8Array(Math.max(count, 256));
+      this._generation = 0;
+    }
+  }
+}

--- a/lightphysics/utils.js
+++ b/lightphysics/utils.js
@@ -13,23 +13,36 @@ function rotatePt(Mx, My, Ox, Oy, cosA, sinA) {
     };
 }
 
+let dioptreCount = 0;
+
 function resetDioptres() {
-    dioptres.length = 0;
-    dioptres.push(new Dioptre(0, 0, width, 0));
-    dioptres.push(new Dioptre(width, 0, width, height));
-    dioptres.push(new Dioptre(width, height, 0, height));
-    dioptres.push(new Dioptre(0, height, 0, 0));
+    dioptreCount = 0;
+    pushDioptre(0, 0, width, 0);
+    pushDioptre(width, 0, width, height);
+    pushDioptre(width, height, 0, height);
+    pushDioptre(0, height, 0, 0);
+}
+
+function pushDioptre(x1, y1, x2, y2) {
+    if (dioptreCount < dioptres.length) {
+        dioptres[dioptreCount].set(x1, y1, x2, y2);
+    } else {
+        dioptres.push(new Dioptre(x1, y1, x2, y2));
+    }
+    dioptreCount++;
 }
 
 function drawLights() {
+    blendMode(ADD);
     for (const light of lights) {
         light.show();
     }
+    blendMode(BLEND);
 }
 
 function drawDioptres() {
-    for (const dioptre of dioptres) {
-        dioptre.show();
+    for (let i = 0; i < dioptreCount; i++) {
+        dioptres[i].show();
     }
 }
 

--- a/sketch.js
+++ b/sketch.js
@@ -25,6 +25,7 @@ let dioptres = [];
 let backgrounds = [];
 let backImg;
 let mouseConstraint;
+let spatialGrid;
 
 function preload() {
   const ballImages = ['ballon.png', 'basket.png', 'smiley.png', 'tennis.png'];
@@ -51,6 +52,8 @@ function setup() {
   World.add(world, mouseConstraint);
 
   backImg = backgrounds[4];
+
+  spatialGrid = new SpatialGrid(CONFIG.CANVAS_WIDTH, CONFIG.CANVAS_HEIGHT, CONFIG.GRID_CELL_SIZE);
 
   createWalls();
   resetDioptres();
@@ -80,6 +83,14 @@ function draw() {
 
   drawLights();
 
+  if (CONFIG.SHOW_FPS) {
+    blendMode(BLEND);
+    noStroke();
+    fill(255, 255, 0);
+    textSize(14);
+    text('FPS: ' + frameRate().toFixed(1), 10, 20);
+  }
+
   Engine.update(engine);
 }
 
@@ -90,6 +101,11 @@ function updateDioptres() {
   }
   for (let i = balls.length - 1; i >= 0; i--) {
     balls[i].pushDioptres();
+  }
+  spatialGrid.updateMaxDioptres(dioptreCount);
+  spatialGrid.build(dioptres, dioptreCount);
+  for (const light of lights) {
+    light.grid = spatialGrid;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR introduces a spatial grid data structure to accelerate ray-dioptre intersection testing in the light physics rendering system. Instead of testing every ray against all dioptres, rays now only test dioptres in cells along their path using DDA (Digital Differential Analyzer) traversal.

## Key Changes

- **New SpatialGrid class** (`lightphysics/spatial-grid.js`): Implements a 2D grid-based acceleration structure that:
  - Divides the canvas into cells and registers each dioptre in all cells it overlaps
  - Uses DDA traversal to efficiently find dioptres along a ray's path
  - Employs a generation counter to avoid clearing the seen array on each query
  - Dynamically grows the tracking array as needed

- **Optimized Ray intersection testing**:
  - Refactored `calculateIntersection()` to use raw coordinate arithmetic instead of p5.Vector operations
  - Added `calculateIntersectionWithGrid()` method that queries the spatial grid before testing intersections
  - Changed `ray.end` from a p5.Vector to a plain object `{x, y}` for better performance

- **Updated Dioptre class**:
  - Changed from storing endpoints as p5.Vectors (`a`, `b`) to raw coordinates (`ax`, `ay`, `bx`, `by`)
  - Added `set()` method for efficient reuse of dioptre objects

- **Refactored Light class**:
  - Removed `lightImg` graphics buffer and `generateLightImg()` method
  - Simplified `show()` to directly render the light polygon
  - Moved ray generation to `initRays()` method
  - Added grid support with conditional path selection in `lookRayCollision()`

- **Updated dioptre management**:
  - Introduced `dioptreCount` variable to track active dioptres
  - Added `pushDioptre()` helper function for efficient dioptre reuse
  - Modified all physics objects (Box, Ball, Paddle) to use `pushDioptre()` instead of direct array push

- **Integrated spatial grid into all sketches**:
  - Added grid initialization and updates in `sketch.js`, `breakout.js`, and `gravity.js`
  - Grid is rebuilt each frame and assigned to lights for use during rendering

- **UI improvements**:
  - Added FPS counter display (controlled by `CONFIG.SHOW_FPS`)
  - Added blending mode management for light rendering

- **Configuration updates**:
  - Added `GRID_CELL_SIZE` (80 pixels) and `SHOW_FPS` config options

## Implementation Details

The spatial grid uses a generation counter technique to avoid repeatedly clearing a tracking array. Each query increments the generation counter, and dioptres are marked with the current generation when added to results. This avoids O(n) array clearing overhead while preventing duplicates in the result set.

The DDA traversal efficiently steps through grid cells along the ray's path, only testing dioptres in cells the ray actually passes through, significantly reducing intersection test count for scenes with many dioptres.

https://claude.ai/code/session_01VU4zPN77f3nuLbBVZuE4TC