### PR TITLE
Add radial gradient fill to light rendering

### DIFF
--- a/lightphysics/light.js
+++ b/lightphysics/light.js
@@ -38,7 +38,33 @@ class Light {
   show() {
     this.lookRayCollision();
 
-    fill(this.color);
+    // Compute max ray distance for gradient radius
+    let maxDistSq = 0;
+    for (const ray of this.rays) {
+      const dx = ray.end.x - this.pos.x;
+      const dy = ray.end.y - this.pos.y;
+      const dSq = dx * dx + dy * dy;
+      if (dSq > maxDistSq) maxDistSq = dSq;
+    }
+    const maxDist = Math.sqrt(maxDistSq);
+
+    // Extract RGBA components
+    const r = red(this.color);
+    const g = green(this.color);
+    const b = blue(this.color);
+    const a = alpha(this.color) / 255;
+
+    // Create radial gradient via native Canvas 2D API
+    const ctx = drawingContext;
+    const gradient = ctx.createRadialGradient(
+      this.pos.x, this.pos.y, 0,
+      this.pos.x, this.pos.y, maxDist
+    );
+    gradient.addColorStop(0, `rgba(${r},${g},${b},${a})`);
+    gradient.addColorStop(1, `rgba(${r},${g},${b},0)`);
+
+    // Draw light polygon with gradient fill
+    ctx.fillStyle = gradient;
     noStroke();
     beginShape();
     for (const ray of this.rays) {


### PR DESCRIPTION
## Summary
Enhanced the light rendering to use a radial gradient fill instead of a solid color, creating a more realistic fade-out effect from the light source.

## Key Changes
- Compute the maximum ray distance to determine the gradient radius
- Extract RGBA color components from the light's color property
- Create a radial gradient using the Canvas 2D API that fades from the light's full color at the center to transparent at the maximum ray distance
- Apply the gradient as the fill style before drawing the light polygon

## Implementation Details
- The gradient radius is calculated by finding the maximum distance from the light's position to any ray endpoint
- Color components are extracted using p5.js color functions (`red()`, `green()`, `blue()`, `alpha()`)
- The gradient is created via native Canvas 2D API (`createRadialGradient()`) for better performance than p5.js alternatives
- The alpha channel is normalized to 0-1 range for CSS rgba format
- The gradient transitions from full opacity at the center to zero opacity at the edges, creating a natural light falloff effect

https://claude.ai/code/session_01P6gAddcrzhq75ieQD13rK6