### PR TITLE
Fix spatial grid boundary clamping for dioptre insertion

### DIFF
--- a/lightphysics/spatial-grid.js
+++ b/lightphysics/spatial-grid.js
@@ -35,10 +35,10 @@ class SpatialGrid {
 
   insertDioptre(dioptre, index) {
     const cs = this.cellSize;
-    const minX = Math.max(0, Math.floor(Math.min(dioptre.ax, dioptre.bx) / cs));
-    const maxX = Math.min(this.cols - 1, Math.floor(Math.max(dioptre.ax, dioptre.bx) / cs));
-    const minY = Math.max(0, Math.floor(Math.min(dioptre.ay, dioptre.by) / cs));
-    const maxY = Math.min(this.rows - 1, Math.floor(Math.max(dioptre.ay, dioptre.by) / cs));
+    const minX = Math.max(0, Math.min(this.cols - 1, Math.floor(Math.min(dioptre.ax, dioptre.bx) / cs)));
+    const maxX = Math.max(0, Math.min(this.cols - 1, Math.floor(Math.max(dioptre.ax, dioptre.bx) / cs)));
+    const minY = Math.max(0, Math.min(this.rows - 1, Math.floor(Math.min(dioptre.ay, dioptre.by) / cs)));
+    const maxY = Math.max(0, Math.min(this.rows - 1, Math.floor(Math.max(dioptre.ay, dioptre.by) / cs)));
 
     for (let y = minY; y <= maxY; y++) {
       for (let x = minX; x <= maxX; x++) {


### PR DESCRIPTION
## Summary
Fixed a bug in the `insertDioptre` method where grid cell indices were not properly clamped to valid boundaries on both the minimum and maximum sides.

## Key Changes
- Updated boundary clamping logic to ensure both `minX`, `maxX`, `minY`, and `maxY` are clamped between 0 and their respective grid limits
- Changed from asymmetric clamping (only clamping max values) to symmetric clamping using `Math.max(0, Math.min(limit, value))` for all four boundaries
- This prevents potential out-of-bounds array access when dioptre coordinates fall outside the grid

## Implementation Details
The previous implementation only clamped the upper bounds (`maxX` and `maxY`) while relying on `Math.max(0, ...)` for lower bounds. The new implementation consistently applies both lower and upper bound constraints to all four variables, ensuring that:
- `minX` and `maxX` stay within `[0, cols - 1]`
- `minY` and `maxY` stay within `[0, rows - 1]`

This is a defensive fix that ensures grid iteration always operates on valid cell indices.

https://claude.ai/code/session_01Vu8ZRHk6MW8Bw1CoQjsbcG