### PR TITLE
Add glass surface tracking and improve refraction handling

### DIFF
--- a/lightphysics/ray.js
+++ b/lightphysics/ray.js
@@ -13,6 +13,8 @@ class Ray {
     this.color = color;
     this.end = { x: pos.x, y: pos.y };
     this.hitDioptreIndex = -1;
+    this.glassEnd = { x: pos.x, y: pos.y };
+    this.hitGlassDioptreIndex = -1;
   }
 
   lookAt(x, y) {
@@ -48,6 +50,7 @@ class Ray {
 
   calculateIntersection(dioptres, dioptreCount) {
     let record = Infinity;
+    let glassRecord = Infinity;
     const posX = this.pos.x;
     const posY = this.pos.y;
     const dirX = this.dir.x;
@@ -61,6 +64,9 @@ class Ray {
     this.end.x = posX;
     this.end.y = posY;
     this.hitDioptreIndex = -1;
+    this.glassEnd.x = posX;
+    this.glassEnd.y = posY;
+    this.hitGlassDioptreIndex = -1;
 
     for (let i = 0; i < count; i++) {
       const surface = dioptres[i];
@@ -82,18 +88,33 @@ class Ray {
         const dx = ptX - posX;
         const dy = ptY - posY;
         const dSq = dx * dx + dy * dy;
-        if (dSq < record) {
-          record = dSq;
-          this.end.x = ptX;
-          this.end.y = ptY;
-          this.hitDioptreIndex = i;
+        if (surface.isGlass) {
+          if (dSq < glassRecord) {
+            glassRecord = dSq;
+            this.glassEnd.x = ptX;
+            this.glassEnd.y = ptY;
+            this.hitGlassDioptreIndex = i;
+          }
+        } else {
+          if (dSq < record) {
+            record = dSq;
+            this.end.x = ptX;
+            this.end.y = ptY;
+            this.hitDioptreIndex = i;
+          }
         }
       }
+    }
+
+    // Discard glass hit if it is behind the closest opaque hit
+    if (glassRecord >= record) {
+      this.hitGlassDioptreIndex = -1;
     }
   }
 
   calculateIntersectionWithGrid(dioptres, grid) {
     let record = Infinity;
+    let glassRecord = Infinity;
     const posX = this.pos.x;
     const posY = this.pos.y;
     const dirX = this.dir.x;
@@ -106,6 +127,9 @@ class Ray {
     this.end.x = posX;
     this.end.y = posY;
     this.hitDioptreIndex = -1;
+    this.glassEnd.x = posX;
+    this.glassEnd.y = posY;
+    this.hitGlassDioptreIndex = -1;
 
     const indices = grid.getDioptresForRay(posX, posY, dirX, dirY);
 
@@ -129,13 +153,27 @@ class Ray {
         const dx = ptX - posX;
         const dy = ptY - posY;
         const dSq = dx * dx + dy * dy;
-        if (dSq < record) {
-          record = dSq;
-          this.end.x = ptX;
-          this.end.y = ptY;
-          this.hitDioptreIndex = indices[i];
+        if (surface.isGlass) {
+          if (dSq < glassRecord) {
+            glassRecord = dSq;
+            this.glassEnd.x = ptX;
+            this.glassEnd.y = ptY;
+            this.hitGlassDioptreIndex = indices[i];
+          }
+        } else {
+          if (dSq < record) {
+            record = dSq;
+            this.end.x = ptX;
+            this.end.y = ptY;
+            this.hitDioptreIndex = indices[i];
+          }
         }
       }
+    }
+
+    // Discard glass hit if it is behind the closest opaque hit
+    if (glassRecord >= record) {
+      this.hitGlassDioptreIndex = -1;
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR enhances the ray tracing system to properly track intersections with glass surfaces separately from opaque surfaces, and fixes refraction calculations to correctly handle rays traveling through glass media.

## Key Changes

- **Separate glass surface tracking**: Added `glassEnd` and `hitGlassDioptreIndex` properties to the Ray class to independently track the closest glass surface intersection, distinct from opaque surface intersections.

- **Dual intersection calculation**: Modified `calculateIntersection()` and `calculateIntersectionWithGrid()` methods to maintain separate distance records for glass and opaque surfaces, with logic to discard glass hits that are occluded by closer opaque surfaces.

- **Fixed refraction medium detection**: Corrected the refraction ratio calculation in `castRefractedBeamForPolygon()` to properly account for the current medium (glass vs. air) when applying Snell's law, using `inGlass ? refractiveIndex : (1.0 / refractiveIndex)` instead of always assuming exit from glass.

- **Updated glass interaction logic**: Changed the glass hit detection in `renderPolygonBeams()` to use `hitGlassDioptreIndex` instead of checking both `hitDioptreIndex` and the `isGlass` property, simplifying the logic and ensuring consistency.

- **Updated ray endpoint references**: Changed all references to use `glassEnd` coordinates when processing glass surface interactions, ensuring accurate positioning for refracted beam calculations.

- **Relaxed intersection tolerance**: Changed the ray-line intersection threshold from `u > 0.001` to `u > 0`, allowing rays to interact with surfaces at their exact endpoints.

## Implementation Details

The changes ensure that:
- Glass surfaces are properly prioritized based on distance while respecting occlusion by opaque surfaces
- Refracted rays correctly toggle the `inGlass` state when entering/exiting glass media
- The refraction ratio is computed correctly for both air-to-glass and glass-to-air transitions
- Ray endpoints used for subsequent refraction calculations are accurate for glass surface interactions

https://claude.ai/code/session_01H2mdv8uRto1CgbSGXtpArK