### PR TITLE
Add paddle rotation support and improve physics collision handling

### DIFF
--- a/breakout.js
+++ b/breakout.js
@@ -99,10 +99,16 @@ function setupBricks(options) {
 }
 
 function setupBorders(options) {
-  boxes.push(new Box(width / 2, -20, width, 60, options, boxesImg));
-  boxes.push(new Box(-20, height / 2, 60, height - 20, options, boxesImg));
-  boxes.push(new Box(width / 2, height + 20, width, 60, options, boxesImg));
-  boxes.push(new Box(width + 20, height / 2, 60, height - 20, options, boxesImg));
+  const borders = [
+    new Box(width / 2, -20, width, 60, options, boxesImg),
+    new Box(-20, height / 2, 60, height - 20, options, boxesImg),
+    new Box(width / 2, height + 20, width, 60, options, boxesImg),
+    new Box(width + 20, height / 2, 60, height - 20, options, boxesImg),
+  ];
+  for (const border of borders) {
+    border.isBorder = true;
+    boxes.push(border);
+  }
 }
 
 function setupBall() {
@@ -139,14 +145,19 @@ function setupCollisionEvents() {
   Matter.Events.on(engine, 'collisionEnd', ({ pairs }) => {
     pairs.forEach(({ bodyA, bodyB }) => {
       if (balls.length === 0) return;
-      let id;
-      if (bodyA.id === balls[0].body.id) {
-        id = bodyB.id;
+      const ballId = balls[0].body.id;
+      // Only process collisions that actually involve the ball
+      let brickId;
+      if (bodyA.id === ballId) {
+        brickId = bodyB.id;
+      } else if (bodyB.id === ballId) {
+        brickId = bodyA.id;
       } else {
-        id = bodyA.id;
+        return; // Ball not involved in this collision
       }
-      for (let i = 0; i < boxes.length - 4; i++) {
-        if (id === boxes[i].body.id) {
+      for (let i = 0; i < boxes.length; i++) {
+        if (boxes[i].body.isStatic && boxes[i].isBorder) continue;
+        if (brickId === boxes[i].body.id) {
           if (random(0, 1) > CONFIG.LIGHT_SPAWN_PROBABILITY) {
             const newcolor = color(random(255), random(255), random(255));
             newcolor.setAlpha(50);
@@ -154,7 +165,7 @@ function setupCollisionEvents() {
           }
           boxes[i].removeFromWorld();
           boxes.splice(i, 1);
-          i--;
+          break;
         }
       }
     });
@@ -176,7 +187,17 @@ function draw() {
   let vy = balls[0].getVY();
   const v = sqrt(vx * vx + vy * vy);
   if (v > CONFIG.BALL_SPEED_MAX) { vx = vx * CONFIG.VELOCITY_DAMPING; vy = vy * CONFIG.VELOCITY_DAMPING; }
-  if (v < CONFIG.BALL_SPEED_MIN) { vx = vx * CONFIG.VELOCITY_BOOST; vy = vy * CONFIG.VELOCITY_BOOST; }
+  if (v < CONFIG.BALL_SPEED_MIN) {
+    if (v < 1e-6) {
+      // Ball is completely stuck: give it a random velocity to unstick
+      const angle = random(TWO_PI);
+      vx = cos(angle) * CONFIG.BREAKOUT_BALL_VELOCITY;
+      vy = sin(angle) * CONFIG.BREAKOUT_BALL_VELOCITY;
+    } else {
+      vx = vx * CONFIG.VELOCITY_BOOST;
+      vy = vy * CONFIG.VELOCITY_BOOST;
+    }
+  }
   MyBody.setVelocity(balls[0].body, { x: vx, y: vy });
 
   if (boxes.length <= 4) {

--- a/lightphysics/ball.js
+++ b/lightphysics/ball.js
@@ -49,7 +49,7 @@ class Ball extends PhysicsObject {
         } else {
             rectMode(CENTER);
             fill(127);
-            circle(0, 0, this.r * 2, this.r * 2);
+            circle(0, 0, this.r * 2);
         }
         pop();
     }

--- a/lightphysics/light.js
+++ b/lightphysics/light.js
@@ -521,7 +521,7 @@ class Light {
   }
 
   finalizePolygonGroup(group) {
-    if (group.count === 0) return;
+    if (group.count === 0 || group.entryPoints.length === 0 || group.exitPoints.length === 0) return;
 
     // Average intensity
     group.intensity = group.intensity / group.count;
@@ -552,7 +552,7 @@ class Light {
     const ctx = drawingContext;
 
     for (const group of this.refractedPolygons) {
-      if (group.count < 2 || group.maxDist < 1) continue;
+      if (group.count < 2 || group.maxDist < 1 || group.exitPoints.length === 0 || group.entryPoints.length === 0) continue;
 
       const alphaVal = Math.min(group.intensity * CONFIG.REFRACTED_BEAM_INTENSITY_BOOST, 1.0);
 

--- a/lightphysics/paddle.js
+++ b/lightphysics/paddle.js
@@ -15,31 +15,47 @@ class Paddle extends PhysicsObject {
     }
 
     pushDioptres() {
-        const pos = this.body.position;
-        pushDioptre(pos.x - this.w / 2, pos.y + this.h / 2, pos.x + this.w / 2, pos.y + this.h / 2);
-        pushDioptre(pos.x + this.w / 2, pos.y + this.h / 2, pos.x + this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3);
-        pushDioptre(pos.x + this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3, pos.x + this.w / 4, pos.y + this.h / 2 - this.h);
-        pushDioptre(pos.x + this.w / 4, pos.y + this.h / 2 - this.h, pos.x - this.w / 4, pos.y + this.h / 2 - this.h);
-        pushDioptre(pos.x - this.w / 4, pos.y + this.h / 2 - this.h, pos.x - this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3);
-        pushDioptre(pos.x - this.w / 2, pos.y + this.h / 2 - this.h * 2 / 3, pos.x - this.w / 2, pos.y + this.h / 2);
+        const cx = this.body.position.x;
+        const cy = this.body.position.y;
+        const angle = this.body.angle;
+        const cosA = Math.cos(-angle);
+        const sinA = Math.sin(-angle);
+
+        // Local-space vertices (relative to body center, offset by h/2)
+        const localVerts = [
+            { x: -this.w / 2, y: this.h / 2 },
+            { x: this.w / 2, y: this.h / 2 },
+            { x: this.w / 2, y: this.h / 2 - this.h * 2 / 3 },
+            { x: this.w / 4, y: -this.h / 2 },
+            { x: -this.w / 4, y: -this.h / 2 },
+            { x: -this.w / 2, y: this.h / 2 - this.h * 2 / 3 },
+        ];
+
+        // Transform to world space with rotation
+        const worldVerts = localVerts.map(v => rotatePt(cx + v.x, cy + v.y, cx, cy, cosA, sinA));
+
+        for (let i = 0; i < worldVerts.length; i++) {
+            const next = (i + 1) % worldVerts.length;
+            pushDioptre(worldVerts[i].x, worldVerts[i].y, worldVerts[next].x, worldVerts[next].y);
+        }
     }
 
     show() {
         push();
         const pos = this.body.position;
+        const angle = this.body.angle;
         strokeWeight(1);
         stroke(255);
         fill(127);
-        translate(pos.x, pos.y + this.h / 2);
+        translate(pos.x, pos.y);
+        rotate(angle);
         beginShape();
-        vertex(0, 0);
-        vertex(this.w / 2, 0);
-        vertex(this.w / 2, -this.h * 2 / 3);
-        vertex(this.w / 4, -this.h);
-        vertex(-this.w / 4, -this.h);
-        vertex(-this.w / 2, -this.h * 2 / 3);
-        vertex(-this.w / 2, 0);
-        vertex(0, 0);
+        vertex(-this.w / 2, this.h / 2);
+        vertex(this.w / 2, this.h / 2);
+        vertex(this.w / 2, this.h / 2 - this.h * 2 / 3);
+        vertex(this.w / 4, -this.h / 2);
+        vertex(-this.w / 4, -this.h / 2);
+        vertex(-this.w / 2, this.h / 2 - this.h * 2 / 3);
         endShape(CLOSE);
         pop();
     }


### PR DESCRIPTION
## Summary
This PR adds rotation support to the paddle physics object and improves collision detection and ball physics handling in the breakout game. Several bug fixes and code quality improvements are also included.

## Key Changes

### Paddle Rotation Support
- Modified `Paddle.pushDioptres()` to account for body rotation when calculating dioptre positions
- Refactored to use local-space vertices that are transformed to world space with rotation applied
- Updated `Paddle.show()` to render the paddle with proper rotation using `rotate(angle)`
- Changed translation point from `(pos.x, pos.y + this.h / 2)` to `(pos.x, pos.y)` for correct rotation center

### Collision Detection Improvements
- Refactored `setupBorders()` to explicitly mark border boxes with `isBorder` flag for easier identification
- Improved collision event handling to properly identify which body is the ball vs. the brick
- Fixed collision loop to skip static border bodies and use `break` instead of `i--` for cleaner logic
- Added early return when ball is not involved in collision

### Ball Physics Fixes
- Added special handling for when ball velocity drops below threshold (v < 1e-6)
- When ball is stuck, apply random velocity impulse to unstick it instead of just boosting
- Fixed `circle()` call in `Ball.show()` to use correct p5.js syntax (removed duplicate radius parameter)

### Light Rendering Safety
- Added null checks in `Light.finalizePolygonGroup()` to prevent errors when entry/exit points are empty
- Added similar safety checks in `Light.drawRefractedBeams()` before accessing point arrays

## Implementation Details
- Paddle rotation uses pre-computed cosine and sine values for efficiency
- Local vertices are defined relative to body center with consistent offset (h/2)
- Border identification uses a simple boolean flag rather than array index magic numbers
- Ball unsticking uses random angle with `CONFIG.BREAKOUT_BALL_VELOCITY` for consistent behavior

https://claude.ai/code/session_01LUqYu8z3LT39eMnLs4VMjy